### PR TITLE
多点触摸时resetCardViewOnStack有可能不被调用

### DIFF
--- a/app/src/main/java/com/lorentzos/flingswipe/FlingCardListener.java
+++ b/app/src/main/java/com/lorentzos/flingswipe/FlingCardListener.java
@@ -148,7 +148,9 @@ public class FlingCardListener implements View.OnTouchListener {
                 case MotionEvent.ACTION_UP:
                 case MotionEvent.ACTION_CANCEL:
                     //mActivePointerId = INVALID_POINTER_ID;
-                    aTouchUpX = event.getX(mActivePointerId);
+                    int pointerCount = event.getPointerCount();
+                    int activePointerId = Math.min(mActivePointerId,pointerCount - 1);
+                    aTouchUpX = event.getX(activePointerId);
                     mActivePointerId = INVALID_POINTER_ID;
                     resetCardViewOnStack(event);
 	                break;


### PR DESCRIPTION
多点触摸时，如果首先松开的为Active Pointer, 在aTouchUpX = event.getX(mActivePointerId)处会抛java.lang.IllegalArgumentException: pointerIndex out of range, 导致resetCardViewOnStack不被调用。
测试机型: Nexus 5x , 系统：Android 6.0。